### PR TITLE
Supporting includable fields

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -324,6 +324,13 @@ class DocumentationGenerator(object):
                 continue
 
             description = getattr(field, 'help_text', '')
+
+            if getattr(field, 'is_includable', False):
+                if description is None:
+                    description = ''
+
+                description = '<font color="#600">[includable]</font> ' + description
+
             if not description or description.strip() == '':
                 description = None
             f = {


### PR DESCRIPTION
A basic support for includable fields. Now they are just market as `[includable]` in dark red. That's enough for the beginning.
